### PR TITLE
Include directories in archive, and the file list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zip
 Title: Cross-Platform 'zip' Compression
-Version: 1.0.0
+Version: 1.0.0.9000
 Author: Gábor Csárdi, Kuba Podgórski, Rich Geldreich
 Maintainer: Gábor Csárdi <csardi.gabor@gmail.com>
 Description: Cross-Platform 'zip' Compression Library. A replacement

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 
+# 1.0.0.9000
+
+* Add empty directories to the archive
+
+* Include directories in the file list
+
 # 1.0.0
 
 First public release.

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,7 +8,10 @@ dir_all <- function(files) {
     seq_along(files),
     function(i) {
       if (info$isdir[i]) {
-        dir(files[i], recursive = TRUE, full.names = TRUE)
+        c(files[i],
+          dir(files[i], recursive = TRUE, full.names = TRUE,
+              include.dirs = TRUE)
+          )
       } else {
         files[i]
       }

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -95,8 +95,8 @@ test_that("single empty directory", {
   expect_true(file.exists(zipfile))
 
   list <- zip_list(zipfile)
-  expect_equal(nrow(list), 0)
-  expect_equal(list$filename, character())
+  expect_equal(nrow(list), 1)
+  expect_equal(list$filename, basename(tmp))
 })
 
 test_that("single empty directory, non-recursive", {
@@ -142,7 +142,7 @@ test_that("appending single empty directory", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
   
   dir.create(tmp2 <- tempfile())
@@ -159,7 +159,7 @@ test_that("appending single empty directory", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2", basename(tmp2))
   )
 })
 
@@ -185,7 +185,7 @@ test_that("appending single empty directory, non-recursive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
   
   dir.create(tmp2 <- tempfile())
@@ -203,6 +203,6 @@ test_that("appending single empty directory, non-recursive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 })

--- a/tests/testthat/test-zip-list.R
+++ b/tests/testthat/test-zip-list.R
@@ -21,7 +21,7 @@ test_that("can list a zip file", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 
   expect_equal(

--- a/tests/testthat/test-zip.R
+++ b/tests/testthat/test-zip.R
@@ -23,7 +23,7 @@ test_that("can compress single directory", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 })
 
@@ -96,7 +96,7 @@ test_that("can compress multiple directories", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2", "file3", "file4")
+    c(basename(tmp1), "file1", "file2", basename(tmp2), "file3", "file4")
   )
 })
 
@@ -124,7 +124,7 @@ test_that("can compress files and directories", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c(basename(file1), "file1", "file2", basename(file2))
+    c(basename(file1), basename(tmp), "file1", "file2", basename(file2))
   )
 })
 
@@ -215,7 +215,7 @@ test_that("can append a directory to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 
   dir.create(tmp2 <- tempfile())
@@ -232,7 +232,7 @@ test_that("can append a directory to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2", "file3", "file4")
+    c(basename(tmp), "file1", "file2", basename(tmp2), "file3", "file4")
   )  
 })
 
@@ -258,7 +258,7 @@ test_that("can append a file to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 
   cat("first file2", file = file1 <- tempfile())
@@ -273,7 +273,7 @@ test_that("can append a file to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2", basename(file1))
+    c(basename(tmp), "file1", "file2", basename(file1))
   )  
 })
 
@@ -299,7 +299,7 @@ test_that("can append files and directories to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2")
+    c(basename(tmp), "file1", "file2")
   )
 
   cat("first file2", file = file1 <- tempfile())
@@ -317,6 +317,7 @@ test_that("can append files and directories to an archive", {
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
-    c("file1", "file2", basename(file1), "file3", "file4")
+    c(basename(tmp), "file1", "file2", basename(file1),
+      basename(tmp2), "file3", "file4")
   )  
 })


### PR DESCRIPTION
This is to be consistent with the tar package,
and it also makes sense for empty directories.