### PR TITLE
Allow manual specification of the ZIP file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .RData
 /src/*.o
 /src/zip.so
+/src/zip.dll
 /revdep
 /README.html
 /sources.zip
@@ -13,3 +14,4 @@
 /src/tools/cmdzip.exe
 /src/tools/cmdzip.dSYM
 /r-packages
+zip.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ License: CC0
 LazyData: true
 URL: https://github.com/r-lib/zip#readme
 BugReports: https://github.com/r-lib/zip/issues
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)
 Suggests:
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # development version
 
+* `zipr()` and `zipr_append()` now support custom filenames in zip files.
+  Use the names of `files` to specify the paths within the zip file (#50).
+
 # 2.0.4
 
 * `unzip_process()` prints better error messages to the standard error,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 # development version
 
 * `zipr()` and `zipr_append()` now support custom filenames in zip files.
-  Use the names of `files` to specify the paths within the zip file (#50).
+  Use the new argument `keys` to specify the paths within the zip file (#50).
+* `unzip_process()` now works when R library is on different drive than `exdir`
+  on Windows (#45)
 
 # 2.0.4
 

--- a/R/process.R
+++ b/R/process.R
@@ -7,12 +7,13 @@ get_tool <- function (prog) {
   if (os_type() == "windows") prog <- paste0(prog, ".exe")
 
   exe <- system.file(package = "zip", "bin", .Platform$r_arch, prog)
-    if (exe == "") {
-      pkgpath <- system.file(package = "zip")
-      if (basename(pkgpath) == "inst") pkgpath <- dirname(pkgpath)
-      exe <- file.path(pkgpath, "src", "tools", prog)
-      if (!file.exists(exe)) return("")
-    }
+  if (exe == "") {
+    pkgpath <- system.file(package = "zip")
+    if (basename(pkgpath) == "inst") pkgpath <- dirname(pkgpath)
+    exe <- file.path(pkgpath, "src", "tools", prog)
+    if (!file.exists(exe)) return("")
+  }
+
   exe
 }
 
@@ -79,7 +80,7 @@ unzip_process <- function() {
           stopifnot(
             is_string(zipfile),
             is_string(exdir))
-          exdir <- normalizePath(exdir, winslash = "/", mustWork = FALSE)
+          exdir <- normalizePath(exdir, winslash = "\\", mustWork = FALSE)
           super$initialize(unzip_exe(), c(zipfile, exdir),
                            poll_connection = poll_connection,
                            stderr = stderr, ...)

--- a/R/process.R
+++ b/R/process.R
@@ -171,8 +171,8 @@ zip_process <- function() {
 }
 
 write_zip_params <- function(files, recurse, include_directories, outfile) {
-  data <- get_zip_data(files, recurse, keep_path = FALSE,
-                       include_directories = include_directories)
+  data <- get_zip_data(files, basename(normalizePath(files)),
+                       recurse, include_directories = include_directories)
   mtime <- as.double(file.info(data$file)$mtime)
 
   con <- file(outfile, open = "wb")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,7 @@
 
 `%||%` <- function(l, r) if (is.null(l)) r else l
 
-get_zip_data <- function(files, recurse, keep_path, include_directories) {
-  if (!keep_path && is.null(names(files))) {
-    names(files) <- basename(normalizePath(files))
-  }
-
-  keys <- names(files) %||% files
+get_zip_data <- function(files, keys, recurse, include_directories) {
   files <- normalizePath(files)
   is_dir <- file.info(files)$isdir
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,34 +2,79 @@
 `%||%` <- function(l, r) if (is.null(l)) r else l
 
 get_zip_data <- function(files, recurse, keep_path, include_directories) {
-  list <- if (keep_path) {
-    get_zip_data_path(files, recurse)
-  } else {
-    get_zip_data_nopath(files, recurse)
+  if (!keep_path && is.null(names(files))) {
+    names(files) <- basename(normalizePath(files))
   }
-
-  if (!include_directories) {
-    list <- list[! list$dir, ]
+  
+  keys <- names(files) %||% files
+  files <- normalizePath(files)
+  is_dir <- file.info(files)$isdir
+  
+  if (!recurse && any(is_dir)) {
+    warning("directories ignored in zip file, specify recurse = TRUE")
+    files <- files[!is_dir]
+    keys <- keys[!is_dir]
+    is_dir <- is_dir[!is_dir]
   }
-
-  list
-}
-
-get_zip_data_path <- function(files, recurse) {
-    if (recurse && length(files)) {
-    data <- do.call(rbind, lapply(files, get_zip_data_path_recursive))
-    dup <- duplicated(data$files)
-    if (any(dup)) data <- data <- data[ !dup, drop = FALSE ]
-    data
-
-  } else {
-    files <- ignore_dirs_with_warning(files)
-    data.frame(
+  
+  if (!length(files)) {
+    return(data.frame(
       stringsAsFactors = FALSE,
-      key = files,
-      files = files,
-      dir = rep(FALSE, length(files))
-    )
+      key = character(),
+      files = character(),
+      dir = logical()
+    ))
+  }
+  
+  zip_data <- do.call(rbind, mapply(
+    function(key, file, is_dir) {
+      if (is_dir) {
+        files <- c(
+          "", # Entry for the parent dir
+          list.files( # Entries for all children (dirs and files)
+            path = file,
+            recursive = TRUE,
+            include.dirs = TRUE,
+            all.files = TRUE,
+            no.. = TRUE
+          )
+        )
+        
+        keys <- file.path(key, files)
+        files <- file.path(file, files)
+        dirs <- file.info(files)$isdir
+        keys[dirs] <- paste0(keys[dirs], "/")
+        
+        data.frame( 
+          stringsAsFactors = FALSE,
+          key = keys,
+          files = files,
+          dir = dirs
+        )
+      } else {
+        data.frame(
+          stringsAsFactors = FALSE,
+          key = key,
+          files = file,
+          dir = FALSE
+        )
+      }
+    },
+    key = keys,
+    file = files,
+    is_dir = is_dir,
+    SIMPLIFY = FALSE
+  ))
+  
+  zip_data <- zip_data[!duplicated(zip_data$key) & zip_data$key != "/", ]
+  
+  row.names(zip_data) <- NULL
+  zip_data$files <- normalizePath(zip_data$files)
+  
+  if (!include_directories) {
+    zip_data[!zip_data$dir, ]
+  } else {
+    zip_data
   }
 }
 
@@ -42,82 +87,6 @@ warn_for_dotdot <- function(files) {
             "creating non-portable zip file")
   }
   files
-}
-
-get_zip_data_nopath <- function(files, recurse) {
-  if (recurse && length(files)) {
-    data <- do.call(rbind, lapply(files, get_zip_data_nopath_recursive))
-    dup <- duplicated(data$files)
-    if (any(dup)) data <- data[ !dup, drop = FALSE ]
-    data
-
-  } else {
-    files <- ignore_dirs_with_warning(files)
-    data.frame(
-      stringsAsFactors = FALSE,
-      key = basename(files),
-      file = files,
-      dir = rep(FALSE, length(files))
-    )
-  }
-}
-
-ignore_dirs_with_warning <- function(files) {
-  info <- file.info(files)
-  if (any(info$isdir)) {
-    warning("directories ignored in zip file, specify recurse = TRUE")
-    files <- files[!info$isdir]
-  }
-  files
-}
-
-get_zip_data_path_recursive <- function(x) {
-  if (file.info(x)$isdir) {
-    files <- c(x, dir(x, recursive = TRUE, full.names = TRUE,
-                      all.files = TRUE, include.dirs = TRUE, no.. = TRUE))
-    dir <- file.info(files)$isdir
-    data.frame(
-      stringsAsFactors = FALSE,
-      key = ifelse(dir, paste0(files, "/"), files),
-      file = normalizePath(files),
-      dir = dir
-    )
-  } else {
-    data.frame(
-      stringsAsFactors = FALSE,
-      key = x,
-      file = normalizePath(x),
-      dir = FALSE
-    )
-  }
-}
-
-get_zip_data_nopath_recursive <- function(x) {
-  x <- normalizePath(x)
-  wd <- getwd()
-  on.exit(setwd(wd))
-  setwd(dirname(x))
-  bnx <- basename(x)
-
-  files <- dir(
-    bnx,
-    recursive = TRUE,
-    all.files = TRUE,
-    include.dirs = TRUE,
-    no.. = TRUE
-  )
-
-  key <- c(bnx, file.path(bnx, files))
-  files <- c(x, file.path(dirname(x), bnx, files))
-  dir <- file.info(files)$isdir
-  key <- ifelse(dir, paste0(key, "/"), key)
-
-  data.frame(
-    stringsAsFactors = FALSE,
-    key = key,
-    file = normalizePath(files),
-    dir = dir
-  )
 }
 
 mkdirp <- function(x, ...) {

--- a/R/zip.R
+++ b/R/zip.R
@@ -80,6 +80,24 @@ NULL
 #'   deprecated = function(e) NULL)
 #' ```
 #'
+#' @section Custom file structure:
+#'
+#' Both `zipr` and `zip` allow manual specification of the file structure using
+#' the names of `files`.
+#'
+#' Assuming files `bar/file1_2`, `dir1/file1_2`, `dir1/file2_2"` and `foo2` to
+#' exist in the current working directory, the names can be used to produce a
+#' custom file structure as follows:
+#'
+#' ```
+#' zipr("x.zip", c("file1" = "bar/file1_2", "dir1" = "dir1_2", "foo2" = "foo2"))
+#' zip_list("x.zip")$filename
+#' #> file1
+#' #> dir1
+#' #> dir1/file1_2
+#' #> dir1/file2_2
+#' #> foo2
+#' ```
 #' @param zipfile The zip file to create. If the file exists, `zip`
 #'   overwrites it, but `zip_append` appends to it.
 #' @param files List of file to add to the archive. See details below

--- a/R/zip.R
+++ b/R/zip.R
@@ -83,7 +83,7 @@ NULL
 #' @section Custom file structure:
 #'
 #' Both `zipr` and `zip` allow manual specification of the file structure using
-#' the names of `files`.
+#' the argument `keys`.
 #'
 #' Assuming files `bar/file1_2`, `dir1/file1_2`, `dir1/file2_2"` and `foo2` to
 #' exist in the current working directory, the names can be used to produce a

--- a/R/zip.R
+++ b/R/zip.R
@@ -90,7 +90,8 @@ NULL
 #' custom file structure as follows:
 #'
 #' ```
-#' zipr("x.zip", c("file1" = "bar/file1_2", "dir1" = "dir1_2", "foo2" = "foo2"))
+#' zipr("x.zip", c("bar/file1_2", "dir1_2", "foo2"),
+#'      keys = c("file1", "dir1", "foo2"))
 #' zip_list("x.zip")$filename
 #' #> file1
 #' #> dir1
@@ -108,6 +109,7 @@ NULL
 #' @param include_directories Whether to explicitly include directories
 #'   in the archive. Including directories might confuse MS Office when
 #'   reading docx files, so set this to `FALSE` for creating them.
+#' @param keys Custom file names to set in the zip archive.
 #' @return The name of the created zip file, invisibly.
 #'
 #' @export
@@ -129,48 +131,50 @@ NULL
 #' zip_list(zipfile)
 
 zip <- function(zipfile, files, recurse = TRUE, compression_level = 9,
-                include_directories = TRUE) {
+                include_directories = TRUE, keys = files) {
   deprecated("zip", "zip::zip() is deprecated, please use zip::zipr() instead")
-  zip_internal(zipfile, files, recurse, compression_level, append = FALSE,
-               keep_path = TRUE, include_directories = include_directories)
+  zip_internal(zipfile, files, keys, recurse, compression_level,
+               append = FALSE, include_directories = include_directories)
 }
 
 #' @rdname zip
 #' @export
-
-zipr <- function(zipfile, files, recurse = TRUE, compression_level = 9,
-                 include_directories = TRUE) {
-  zip_internal(zipfile, files, recurse, compression_level, append = FALSE,
-               keep_path = FALSE, include_directories = include_directories)
+zipr <- function(zipfile, files, recurse = TRUE,
+                 compression_level = 9, include_directories = TRUE,
+                 keys = basename(normalizePath(files))) {
+  zip_internal(zipfile, files, keys, recurse, compression_level,
+               append = FALSE, include_directories = include_directories)
 }
 
 #' @rdname zip
 #' @export
 
 zip_append <- function(zipfile, files, recurse = TRUE,
-                       compression_level = 9, include_directories = TRUE) {
+                       compression_level = 9, include_directories = TRUE,
+                       keys = files) {
   deprecated(
     "zip_append",
     "zip::zip_append() is deprecated, please use zip::zipr_append instead")
-  zip_internal(zipfile, files, recurse, compression_level, append = TRUE,
-               keep_path = TRUE, include_directories = include_directories)
+  zip_internal(zipfile, files, keys, recurse, compression_level,
+               append = TRUE, include_directories = include_directories)
 }
 
 #' @rdname zip
 #' @export
 
 zipr_append <- function(zipfile, files, recurse = TRUE,
-                        compression_level = 9, include_directories = TRUE) {
-  zip_internal(zipfile, files, recurse, compression_level, append = TRUE,
-               keep_path = FALSE, include_directories = include_directories)
+                        compression_level = 9, include_directories = TRUE,
+                        keys = basename(normalizePath(files))) {
+  zip_internal(zipfile, files, keys, recurse, compression_level,
+               append = TRUE, include_directories = include_directories)
 }
 
-zip_internal <- function(zipfile, files, recurse, compression_level,
-                         append, keep_path, include_directories) {
+zip_internal <- function(zipfile, files, keys, recurse, compression_level,
+                         append, include_directories) {
 
   if (any(! file.exists(files))) stop("Some files do not exist")
 
-  data <- get_zip_data(files, recurse, keep_path, include_directories)
+  data <- get_zip_data(files, keys, recurse, include_directories)
   warn_for_dotdot(data$key)
 
   .Call(c_R_zip_zip, zipfile, data$key, data$file, data$dir,

--- a/man/unzip.Rd
+++ b/man/unzip.Rd
@@ -4,8 +4,7 @@
 \alias{unzip}
 \title{Uncompress 'zip' Archives}
 \usage{
-unzip(zipfile, files = NULL, overwrite = TRUE, junkpaths = FALSE,
-  exdir = ".")
+unzip(zipfile, files = NULL, overwrite = TRUE, junkpaths = FALSE, exdir = ".")
 }
 \arguments{
 \item{zipfile}{Path to the zip file to uncompress.}

--- a/man/zip.Rd
+++ b/man/zip.Rd
@@ -142,7 +142,7 @@ use something like this:\preformatted{withCallingHandlers(
 
 
 Both \code{zipr} and \code{zip} allow manual specification of the file structure using
-the names of \code{files}.
+the argument \code{keys}.
 
 Assuming files \code{bar/file1_2}, \code{dir1/file1_2}, \verb{dir1/file2_2"} and \code{foo2} to
 exist in the current working directory, the names can be used to produce a

--- a/man/zip.Rd
+++ b/man/zip.Rd
@@ -7,17 +7,37 @@
 \alias{zipr_append}
 \title{Compress Files into 'zip' Archives}
 \usage{
-zip(zipfile, files, recurse = TRUE, compression_level = 9,
-  include_directories = TRUE)
+zip(
+  zipfile,
+  files,
+  recurse = TRUE,
+  compression_level = 9,
+  include_directories = TRUE
+)
 
-zipr(zipfile, files, recurse = TRUE, compression_level = 9,
-  include_directories = TRUE)
+zipr(
+  zipfile,
+  files,
+  recurse = TRUE,
+  compression_level = 9,
+  include_directories = TRUE
+)
 
-zip_append(zipfile, files, recurse = TRUE, compression_level = 9,
-  include_directories = TRUE)
+zip_append(
+  zipfile,
+  files,
+  recurse = TRUE,
+  compression_level = 9,
+  include_directories = TRUE
+)
 
-zipr_append(zipfile, files, recurse = TRUE, compression_level = 9,
-  include_directories = TRUE)
+zipr_append(
+  zipfile,
+  files,
+  recurse = TRUE,
+  compression_level = 9,
+  include_directories = TRUE
+)
 }
 \arguments{
 \item{zipfile}{The zip file to create. If the file exists, \code{zip}
@@ -60,15 +80,15 @@ omitted, even on Unix.
 \section{Relative paths}{
 
 
-The different between \code{zipr} and \code{zip} is how they handle the relative
+The difference between \code{zipr} and \code{zip} is how they handle the relative
 paths of the input files.
 
 For \code{zip} (and \code{zip_append}), the root of the archive is supposed to
 be the current working directory. The paths of the files are fully kept
 in the archive. Absolute paths are also kept. Note that this might result
 non-portable archives: some zip tools do not handle zip archives that
-contain absolute file names, or file names that start with \code{..//} or
-\code{./}. This behavior is kept for compatibility, and we suggest that you
+contain absolute file names, or file names that start with \verb{..//} or
+\verb{./}. This behavior is kept for compatibility, and we suggest that you
 use \code{zipr} and \code{zipr_append} for new code.
 
 E.g. for the following directory structure:\preformatted{foo
@@ -109,6 +129,24 @@ will trigger a reminder message. To suppress this message, you can
 use something like this:\preformatted{withCallingHandlers(
   zip::zip(...),
   deprecated = function(e) NULL)
+}
+}
+
+\section{Custom file structure}{
+
+
+Both \code{zipr} and \code{zip} allow manual specification of the file structure using
+the names of \code{files}.
+
+Assuming files \code{bar/file1_2}, \code{dir1/file1_2}, \verb{dir1/file2_2"} and \code{foo2} to
+exist in the current working directory, the names can be used to produce a
+custom file structure as follows:\preformatted{zipr("x.zip", c("file1" = "bar/file1_2", "dir1" = "dir1_2", "foo2" = "foo2"))
+zip_list("x.zip")$filename
+#> file1
+#> dir1
+#> dir1/file1_2
+#> dir1/file2_2
+#> foo2
 }
 }
 

--- a/man/zip.Rd
+++ b/man/zip.Rd
@@ -12,7 +12,8 @@ zip(
   files,
   recurse = TRUE,
   compression_level = 9,
-  include_directories = TRUE
+  include_directories = TRUE,
+  keys = files
 )
 
 zipr(
@@ -20,7 +21,8 @@ zipr(
   files,
   recurse = TRUE,
   compression_level = 9,
-  include_directories = TRUE
+  include_directories = TRUE,
+  keys = basename(normalizePath(files))
 )
 
 zip_append(
@@ -28,7 +30,8 @@ zip_append(
   files,
   recurse = TRUE,
   compression_level = 9,
-  include_directories = TRUE
+  include_directories = TRUE,
+  keys = files
 )
 
 zipr_append(
@@ -36,7 +39,8 @@ zipr_append(
   files,
   recurse = TRUE,
   compression_level = 9,
-  include_directories = TRUE
+  include_directories = TRUE,
+  keys = basename(normalizePath(files))
 )
 }
 \arguments{
@@ -54,6 +58,8 @@ but it also takes the longest.}
 \item{include_directories}{Whether to explicitly include directories
 in the archive. Including directories might confuse MS Office when
 reading docx files, so set this to \code{FALSE} for creating them.}
+
+\item{keys}{Custom file names to set in the zip archive.}
 }
 \value{
 The name of the created zip file, invisibly.
@@ -140,7 +146,8 @@ the names of \code{files}.
 
 Assuming files \code{bar/file1_2}, \code{dir1/file1_2}, \verb{dir1/file2_2"} and \code{foo2} to
 exist in the current working directory, the names can be used to produce a
-custom file structure as follows:\preformatted{zipr("x.zip", c("file1" = "bar/file1_2", "dir1" = "dir1_2", "foo2" = "foo2"))
+custom file structure as follows:\preformatted{zipr("x.zip", c("bar/file1_2", "dir1_2", "foo2"),
+     keys = c("file1", "dir1", "foo2"))
 zip_list("x.zip")$filename
 #> file1
 #> dir1

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -44,6 +44,10 @@ bns <- function(x) {
   paste0(basename(x), "/")
 }
 
+bnn <- function(x) {
+  basename(normalizePath(x))
+}
+
 test_temp_file <- function(fileext = "", pattern = "test-file-",
                            envir = parent.frame(), create = TRUE) {
   tmp <- tempfile(pattern = pattern, fileext = fileext)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -3,7 +3,7 @@ df <- function(key, file, dir = FALSE) {
   data.frame(
     stringsAsFactors = FALSE,
     key = key,
-    file = file,
+    files = file,
     dir = dir
   )
 }

--- a/tests/testthat/test-get-zip-data-path.R
+++ b/tests/testthat/test-get-zip-data-path.R
@@ -6,38 +6,32 @@ test_that("get_zip_data", {
   dir.create(tmp <- tempfile())
 
   expect_equal(
-    get_zip_data_path_recursive(tmp),
+    get_zip_data(tmp, TRUE, TRUE, TRUE),
     df(paste0(tmp, "/"), normalizePath(tmp), TRUE)
   )
-  expect_equal(get_zip_data_path_recursive(tmp), get_zip_data_path(tmp, TRUE))
 
   foobar <- file.path(tmp, "foobar")
   cat("foobar", file = foobar)
 
   expect_equal(
-    get_zip_data_path_recursive(foobar),
+    get_zip_data(foobar, TRUE, TRUE, TRUE),
     df(foobar, normalizePath(foobar), FALSE)
   )
-  expect_equal(get_zip_data_path_recursive(foobar), get_zip_data_path(foobar, TRUE))
 
   expect_equal(
-    get_zip_data_path_recursive(tmp),
+    get_zip_data(tmp, TRUE, TRUE, TRUE),
     df(c(paste0(tmp, "/"), file.path(tmp, "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
        )
   )
-  expect_equal(get_zip_data_path_recursive(tmp), get_zip_data_path(tmp, TRUE))
 
   expect_equal(
-    withr::with_dir(tmp, get_zip_data_path_recursive(".")),
+    withr::with_dir(tmp, get_zip_data(".", TRUE, TRUE, TRUE)),
     df(c("./", "./foobar"),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
        )
-  )
-  withr::with_dir(tmp,
-    expect_equal(get_zip_data_path_recursive("."), get_zip_data_path(".", TRUE))
   )
 
   dir.create(file.path(tmp, "empty"))
@@ -59,22 +53,21 @@ test_that("get_zip_data", {
   data <- data[order(data$file), ]
   rownames(data) <- NULL
 
-  data2 <- get_zip_data_path_recursive(tmp)
+  data2 <- get_zip_data(tmp, TRUE, TRUE, TRUE)
   data2  <- data2[order(data2$file), ]
   rownames(data2) <- NULL
 
   expect_equal(data2, data)
-  expect_equal(get_zip_data_path(tmp, TRUE), data)
 
   expect_equal(
-    get_zip_data_path(c(foobar, bar), TRUE),
+    get_zip_data(c(foobar, bar), TRUE, TRUE, TRUE),
     df(c(foobar, bar),
        normalizePath(c(foobar, bar)),
        c(FALSE, FALSE))
   )
 
   expect_equal(
-    get_zip_data_path(file.path(tmp, "foo"), TRUE),
+    get_zip_data(file.path(tmp, "foo"), TRUE, TRUE, TRUE),
     df(c(paste0(file.path(tmp, "foo"), "/"), file.path(tmp, "foo", "bar")),
        normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
        c(TRUE, FALSE)
@@ -93,7 +86,7 @@ test_that("get_zip_data relative paths", {
   withr::with_dir(
     file.path(tmp, "foo"),
     expect_equal(
-      get_zip_data_path(file.path("..", "foo"), TRUE),
+      get_zip_data(file.path("..", "foo"), TRUE, TRUE, TRUE),
       df(paste0(c(file.path("..", "foo"), file.path("..", "foo", "bar")), "/"),
          normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
          c(TRUE, TRUE)

--- a/tests/testthat/test-get-zip-data-path.R
+++ b/tests/testthat/test-get-zip-data-path.R
@@ -6,7 +6,7 @@ test_that("get_zip_data", {
   dir.create(tmp <- tempfile())
 
   expect_equal(
-    get_zip_data(tmp, TRUE, TRUE, TRUE),
+    get_zip_data(tmp, tmp, TRUE, TRUE),
     df(paste0(tmp, "/"), normalizePath(tmp), TRUE)
   )
 
@@ -14,12 +14,12 @@ test_that("get_zip_data", {
   cat("foobar", file = foobar)
 
   expect_equal(
-    get_zip_data(foobar, TRUE, TRUE, TRUE),
+    get_zip_data(foobar, foobar, TRUE, TRUE),
     df(foobar, normalizePath(foobar), FALSE)
   )
 
   expect_equal(
-    get_zip_data(tmp, TRUE, TRUE, TRUE),
+    get_zip_data(tmp, tmp, TRUE, TRUE),
     df(c(paste0(tmp, "/"), file.path(tmp, "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
@@ -27,7 +27,7 @@ test_that("get_zip_data", {
   )
 
   expect_equal(
-    withr::with_dir(tmp, get_zip_data(".", TRUE, TRUE, TRUE)),
+    withr::with_dir(tmp, get_zip_data(".", ".", TRUE, TRUE)),
     df(c("./", "./foobar"),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
@@ -53,21 +53,21 @@ test_that("get_zip_data", {
   data <- data[order(data$file), ]
   rownames(data) <- NULL
 
-  data2 <- get_zip_data(tmp, TRUE, TRUE, TRUE)
+  data2 <- get_zip_data(tmp, tmp, TRUE, TRUE)
   data2  <- data2[order(data2$file), ]
   rownames(data2) <- NULL
 
   expect_equal(data2, data)
 
   expect_equal(
-    get_zip_data(c(foobar, bar), TRUE, TRUE, TRUE),
+    get_zip_data(c(foobar, bar), c(foobar, bar), TRUE, TRUE),
     df(c(foobar, bar),
        normalizePath(c(foobar, bar)),
        c(FALSE, FALSE))
   )
 
   expect_equal(
-    get_zip_data(file.path(tmp, "foo"), TRUE, TRUE, TRUE),
+    get_zip_data(file.path(tmp, "foo"), file.path(tmp, "foo"), TRUE, TRUE),
     df(c(paste0(file.path(tmp, "foo"), "/"), file.path(tmp, "foo", "bar")),
        normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
        c(TRUE, FALSE)
@@ -86,7 +86,7 @@ test_that("get_zip_data relative paths", {
   withr::with_dir(
     file.path(tmp, "foo"),
     expect_equal(
-      get_zip_data(file.path("..", "foo"), TRUE, TRUE, TRUE),
+      get_zip_data(file.path("..", "foo"), file.path("..", "foo"), TRUE, TRUE),
       df(paste0(c(file.path("..", "foo"), file.path("..", "foo", "bar")), "/"),
          normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
          c(TRUE, TRUE)

--- a/tests/testthat/test-get-zip-data.R
+++ b/tests/testthat/test-get-zip-data.R
@@ -6,38 +6,32 @@ test_that("get_zip_data", {
   dir.create(tmp <- tempfile())
 
   expect_equal(
-    get_zip_data_nopath_recursive(tmp),
+    get_zip_data(tmp, TRUE, FALSE, TRUE),
     df(paste0(basename(tmp), "/"), normalizePath(tmp), TRUE)
   )
-  expect_equal(get_zip_data_nopath_recursive(tmp), get_zip_data_nopath(tmp, TRUE))
 
   foobar <- file.path(tmp, "foobar")
   cat("foobar", file = foobar)
 
   expect_equal(
-    get_zip_data_nopath_recursive(foobar),
+    get_zip_data(foobar, TRUE, FALSE, TRUE),
     df(basename(foobar), normalizePath(foobar), FALSE)
   )
-  expect_equal(get_zip_data_nopath_recursive(foobar), get_zip_data_nopath(foobar, TRUE))
 
   expect_equal(
-    get_zip_data_nopath_recursive(tmp),
+    get_zip_data(tmp, TRUE, FALSE, TRUE),
     df(c(paste0(basename(tmp), "/"), file.path(basename(tmp), "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
        )
   )
-  expect_equal(get_zip_data_nopath_recursive(tmp), get_zip_data_nopath(tmp, TRUE))
 
   expect_equal(
-    withr::with_dir(tmp, get_zip_data_nopath_recursive(".")),
+    withr::with_dir(tmp, get_zip_data(".", TRUE, FALSE, TRUE)),
     df(c(paste0(basename(tmp), "/"), file.path(basename(tmp), "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
        )
-  )
-  withr::with_dir(tmp,
-    expect_equal(get_zip_data_nopath_recursive("."), get_zip_data_nopath(".", TRUE))
   )
 
   dir.create(file.path(tmp, "empty"))
@@ -59,22 +53,21 @@ test_that("get_zip_data", {
   data <- data[order(data$file), ]
   rownames(data) <- NULL
 
-  data2 <- get_zip_data_nopath_recursive(tmp)
+  data2 <- get_zip_data(tmp, TRUE, FALSE, TRUE)
   data2 <- data2[order(data2$file), ]
   rownames(data2) <- NULL
 
   expect_equal(data2, data)
-  expect_equal(get_zip_data_nopath(tmp, TRUE), data)
 
   expect_equal(
-    get_zip_data_nopath(c(foobar, bar), TRUE),
+    get_zip_data(c(foobar, bar), TRUE, FALSE, TRUE),
     df(c("foobar", "bar"),
        normalizePath(c(foobar, bar)),
        c(FALSE, FALSE))
   )
 
   expect_equal(
-    get_zip_data_nopath(file.path(tmp, "foo"), TRUE),
+    get_zip_data(file.path(tmp, "foo"), TRUE, FALSE, TRUE),
     df(c("foo/", "foo/bar"),
        normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
        c(TRUE, FALSE)

--- a/tests/testthat/test-get-zip-data.R
+++ b/tests/testthat/test-get-zip-data.R
@@ -6,7 +6,7 @@ test_that("get_zip_data", {
   dir.create(tmp <- tempfile())
 
   expect_equal(
-    get_zip_data(tmp, TRUE, FALSE, TRUE),
+    get_zip_data(tmp, bnn(tmp), TRUE, TRUE),
     df(paste0(basename(tmp), "/"), normalizePath(tmp), TRUE)
   )
 
@@ -14,12 +14,12 @@ test_that("get_zip_data", {
   cat("foobar", file = foobar)
 
   expect_equal(
-    get_zip_data(foobar, TRUE, FALSE, TRUE),
+    get_zip_data(foobar, bnn(foobar), TRUE, TRUE),
     df(basename(foobar), normalizePath(foobar), FALSE)
   )
 
   expect_equal(
-    get_zip_data(tmp, TRUE, FALSE, TRUE),
+    get_zip_data(tmp, bnn(tmp), TRUE, TRUE),
     df(c(paste0(basename(tmp), "/"), file.path(basename(tmp), "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
@@ -27,7 +27,7 @@ test_that("get_zip_data", {
   )
 
   expect_equal(
-    withr::with_dir(tmp, get_zip_data(".", TRUE, FALSE, TRUE)),
+    withr::with_dir(tmp, get_zip_data(".", bnn("."), TRUE, TRUE)),
     df(c(paste0(basename(tmp), "/"), file.path(basename(tmp), "foobar")),
        normalizePath(c(tmp, foobar)),
        c(TRUE, FALSE)
@@ -53,21 +53,21 @@ test_that("get_zip_data", {
   data <- data[order(data$file), ]
   rownames(data) <- NULL
 
-  data2 <- get_zip_data(tmp, TRUE, FALSE, TRUE)
+  data2 <- get_zip_data(tmp, bnn(tmp), TRUE, TRUE)
   data2 <- data2[order(data2$file), ]
   rownames(data2) <- NULL
 
   expect_equal(data2, data)
 
   expect_equal(
-    get_zip_data(c(foobar, bar), TRUE, FALSE, TRUE),
+    get_zip_data(c(foobar, bar), bnn(c(foobar, bar)), TRUE, TRUE),
     df(c("foobar", "bar"),
        normalizePath(c(foobar, bar)),
        c(FALSE, FALSE))
   )
 
   expect_equal(
-    get_zip_data(file.path(tmp, "foo"), TRUE, FALSE, TRUE),
+    get_zip_data(file.path(tmp, "foo"), bnn(file.path(tmp, "foo")), TRUE, TRUE),
     df(c("foo/", "foo/bar"),
        normalizePath(c(file.path(tmp, "foo"), file.path(tmp, "foo", "bar"))),
        c(TRUE, FALSE)

--- a/tests/testthat/test-zipr.R
+++ b/tests/testthat/test-zipr.R
@@ -146,7 +146,8 @@ test_that("can use names to create custom structure", {
   expect_silent(
     withr::with_dir(
       tmp,
-      zipr(zipfile, c("file1_z" = file1, "file2_z" = file2, "dir1_z" = "dir1"))
+      zipr(zipfile, c(file1, file2, "dir1"),
+           keys = c("file1_z", "file2_z", "dir1_z"))
     )
   )
 

--- a/tests/testthat/test-zipr.R
+++ b/tests/testthat/test-zipr.R
@@ -131,6 +131,34 @@ test_that("can compress files and directories", {
   )
 })
 
+test_that("can use names to create custom structure", {
+  on.exit(try(unlink(c(zipfile, tmp, file1, file2), recursive = TRUE)))
+
+  dir.create(tmp <- tempfile())
+  dir.create(dir <- file.path(tmp, "dir1"))
+  cat("first file", file = file.path(dir, "file1"))
+  cat("second file", file = file.path(dir, "file2"))
+  cat("third file", file = file1 <- tempfile())
+  cat("fourth file", file = file2 <- tempfile())
+
+  zipfile <- tempfile(fileext = ".zip")
+
+  expect_silent(
+    withr::with_dir(
+      tmp,
+      zipr(zipfile, c("file1_z" = file1, "file2_z" = file2, "dir1_z" = "dir1"))
+    )
+  )
+
+  expect_true(file.exists(zipfile))
+
+  list <- zip_list(zipfile)
+  expect_equal(
+    list$filename,
+    c("file1_z", "file2_z", "dir1_z/", "dir1_z/file1", "dir1_z/file2")
+  )
+})
+
 test_that("warning for directories in non-recursive mode", {
 
   on.exit(try(unlink(c(zipfile, tmp, file1, file2), recursive = TRUE)))


### PR DESCRIPTION
fixes #50

TODOs:

- [x] update documentation
- [x] write tests for new functionality

I did a major rewrite of all the `get_zip_data` related functions to reduce duplication and rewrote all tests that previously directly used those functions.

All tests pass on my machine (R 4.0.0, Windows 10)

I didn't update the `zip` documentation yet, but the feature should be complete.