### PR TITLE
Teach ziplist to return crc32 and offset (optionally)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Header values (of version made by and external attributes) are now correctly
   read and written on big-endian systems (#68).
 
+* `zip_list()` now also returns `crc32` and `offset` (#74, thanks @jefferis).
+
 # 2.1.1
 
 This version has no user visible changes.

--- a/R/zip.R
+++ b/R/zip.R
@@ -214,6 +214,7 @@ zip_list <- function(zipfile) {
   Encoding(df$filename) <- "UTF-8"
   df$permissions <- as.octmode(res[[5]])
   df$crc32 <- as.hexmode(res[[6]])
+  df$offset <- res[[7]]
   df
 }
 

--- a/R/zip.R
+++ b/R/zip.R
@@ -194,18 +194,20 @@ zip_internal <- function(zipfile, files, recurse, compression_level,
 
 #' List Files in a 'zip' Archive
 #'
+#' @details Note that `crc32` is formatted using `as.hexmode()`. `offset` refers
+#'   to the start of the local zip header for each entry. Following the approach
+#'   of `seek()` it is stored as a `numeric` rather than an `integer` vector and
+#'   can therefore represent values up to `2^53-1` (9 PB).
 #' @param zipfile Path to an existing ZIP file.
-#' @param extra Whether to return the crc32 and offset for each zip entry (default `FALSE`).
 #' @return A data frame with columns: `filename`, `compressed_size`,
-#'   `uncompressed_size`, `timestamp`, `permissions`. When `extra=TRUE` also
-#'   `crc32` and `offset`.
+#'   `uncompressed_size`, `timestamp`, `permissions`, `crc32` and `offset`.
 #'
 #' @family zip/unzip functions
 #' @export
 
-zip_list <- function(zipfile, extra=FALSE) {
+zip_list <- function(zipfile) {
   zipfile <- enc2utf8(normalizePath(zipfile))
-  res <- .Call(c_R_zip_list, zipfile, extra)
+  res <- .Call(c_R_zip_list, zipfile)
   df <- data.frame(
     stringsAsFactors = FALSE,
     filename = res[[1]],
@@ -215,10 +217,8 @@ zip_list <- function(zipfile, extra=FALSE) {
   )
   Encoding(df$filename) <- "UTF-8"
   df$permissions <- as.octmode(res[[5]])
-  if(extra){
-    df$crc32 <- as.hexmode(res[[6]])
-    df$offset <- res[[7]]
-  }
+  df$crc32 <- as.hexmode(res[[6]])
+  df$offset <- res[[7]]
   df
 }
 

--- a/R/zip.R
+++ b/R/zip.R
@@ -213,6 +213,7 @@ zip_list <- function(zipfile) {
   )
   Encoding(df$filename) <- "UTF-8"
   df$permissions <- as.octmode(res[[5]])
+  df$crc32 <- as.hexmode(res[[6]])
   df
 }
 

--- a/R/zip.R
+++ b/R/zip.R
@@ -195,15 +195,17 @@ zip_internal <- function(zipfile, files, recurse, compression_level,
 #' List Files in a 'zip' Archive
 #'
 #' @param zipfile Path to an existing ZIP file.
+#' @param extra Whether to return the crc32 and offset for each zip entry (default `FALSE`).
 #' @return A data frame with columns: `filename`, `compressed_size`,
-#'   `uncompressed_size`, `timestamp`, `permissions`.
+#'   `uncompressed_size`, `timestamp`, `permissions`. When `extra=TRUE` also
+#'   `crc32` and `offset`.
 #'
 #' @family zip/unzip functions
 #' @export
 
-zip_list <- function(zipfile) {
+zip_list <- function(zipfile, extra=FALSE) {
   zipfile <- enc2utf8(normalizePath(zipfile))
-  res <- .Call(c_R_zip_list, zipfile)
+  res <- .Call(c_R_zip_list, zipfile, extra)
   df <- data.frame(
     stringsAsFactors = FALSE,
     filename = res[[1]],
@@ -213,8 +215,10 @@ zip_list <- function(zipfile) {
   )
   Encoding(df$filename) <- "UTF-8"
   df$permissions <- as.octmode(res[[5]])
-  df$crc32 <- as.hexmode(res[[6]])
-  df$offset <- res[[7]]
+  if(extra){
+    df$crc32 <- as.hexmode(res[[6]])
+    df$offset <- res[[7]]
+  }
   df
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -11,7 +11,7 @@ extern SEXP R_zip_unzip(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_make_big_file(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-  { "R_zip_list",      (DL_FUNC) &R_zip_list,      2 },
+  { "R_zip_list",      (DL_FUNC) &R_zip_list,      1 },
   { "R_zip_zip",       (DL_FUNC) &R_zip_zip,       7 },
   { "R_zip_unzip",     (DL_FUNC) &R_zip_unzip,     5 },
   { "R_make_big_file", (DL_FUNC) &R_make_big_file, 2 },

--- a/src/init.c
+++ b/src/init.c
@@ -11,7 +11,7 @@ extern SEXP R_zip_unzip(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_make_big_file(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-  { "R_zip_list",      (DL_FUNC) &R_zip_list,      1 },
+  { "R_zip_list",      (DL_FUNC) &R_zip_list,      2 },
   { "R_zip_zip",       (DL_FUNC) &R_zip_zip,       7 },
   { "R_zip_unzip",     (DL_FUNC) &R_zip_unzip,     5 },
   { "R_make_big_file", (DL_FUNC) &R_make_big_file, 2 },

--- a/src/rzip.c
+++ b/src/rzip.c
@@ -55,13 +55,15 @@ SEXP R_zip_list(SEXP zipfile) {
   }
 
   num_files = mz_zip_reader_get_num_files(&zip_archive);
-  result = PROTECT(allocVector(VECSXP, 6));
+  result = PROTECT(allocVector(VECSXP, 7));
   SET_VECTOR_ELT(result, 0, allocVector(STRSXP, num_files));
   SET_VECTOR_ELT(result, 1, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 2, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 3, allocVector(INTSXP, num_files));
   SET_VECTOR_ELT(result, 4, allocVector(INTSXP, num_files));
   SET_VECTOR_ELT(result, 5, allocVector(INTSXP, num_files));
+  /* we will use this for the 64 bit local header offset */
+  SET_VECTOR_ELT(result, 6, allocVector(REALSXP, num_files));
 
   for (i = 0; i < num_files; i++) {
     mz_zip_archive_file_stat file_stat;
@@ -76,6 +78,7 @@ SEXP R_zip_list(SEXP zipfile) {
     zip_get_permissions(&file_stat, &mode);
     INTEGER(VECTOR_ELT(result, 4))[i] = (int) mode;
     INTEGER(VECTOR_ELT(result, 5))[i] = (int) file_stat.m_crc32;
+    REAL(VECTOR_ELT(result, 6))[i] = (double) file_stat.m_local_header_ofs;
   }
 
   fclose(fh);

--- a/src/rzip.c
+++ b/src/rzip.c
@@ -55,12 +55,13 @@ SEXP R_zip_list(SEXP zipfile) {
   }
 
   num_files = mz_zip_reader_get_num_files(&zip_archive);
-  result = PROTECT(allocVector(VECSXP, 5));
+  result = PROTECT(allocVector(VECSXP, 6));
   SET_VECTOR_ELT(result, 0, allocVector(STRSXP, num_files));
   SET_VECTOR_ELT(result, 1, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 2, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 3, allocVector(INTSXP, num_files));
   SET_VECTOR_ELT(result, 4, allocVector(INTSXP, num_files));
+  SET_VECTOR_ELT(result, 5, allocVector(INTSXP, num_files));
 
   for (i = 0; i < num_files; i++) {
     mz_zip_archive_file_stat file_stat;
@@ -74,6 +75,7 @@ SEXP R_zip_list(SEXP zipfile) {
     INTEGER(VECTOR_ELT(result, 3))[i] = (int) file_stat.m_time;
     zip_get_permissions(&file_stat, &mode);
     INTEGER(VECTOR_ELT(result, 4))[i] = (int) mode;
+    INTEGER(VECTOR_ELT(result, 5))[i] = (int) file_stat.m_crc32;
   }
 
   fclose(fh);

--- a/src/rzip.c
+++ b/src/rzip.c
@@ -15,9 +15,8 @@
 #include "miniz.h"
 #include "zip.h"
 
-SEXP R_zip_list(SEXP zipfile, SEXP extra) {
+SEXP R_zip_list(SEXP zipfile) {
   const char *czipfile = CHAR(STRING_ELT(zipfile, 0));
-  int cextra = LOGICAL(extra)[0];
   size_t num_files;
   unsigned int i;
   SEXP result = R_NilValue;
@@ -56,16 +55,14 @@ SEXP R_zip_list(SEXP zipfile, SEXP extra) {
   }
 
   num_files = mz_zip_reader_get_num_files(&zip_archive);
-  result = PROTECT(allocVector(VECSXP, cextra?7:5));
+  result = PROTECT(allocVector(VECSXP, 7));
   SET_VECTOR_ELT(result, 0, allocVector(STRSXP, num_files));
   SET_VECTOR_ELT(result, 1, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 2, allocVector(REALSXP, num_files));
   SET_VECTOR_ELT(result, 3, allocVector(INTSXP, num_files));
   SET_VECTOR_ELT(result, 4, allocVector(INTSXP, num_files));
-  if(cextra) {
-    SET_VECTOR_ELT(result, 5, allocVector(INTSXP, num_files));
-    SET_VECTOR_ELT(result, 6, allocVector(REALSXP, num_files));
-  }
+  SET_VECTOR_ELT(result, 5, allocVector(INTSXP, num_files));
+  SET_VECTOR_ELT(result, 6, allocVector(REALSXP, num_files));
 
   for (i = 0; i < num_files; i++) {
     mz_zip_archive_file_stat file_stat;
@@ -79,10 +76,8 @@ SEXP R_zip_list(SEXP zipfile, SEXP extra) {
     INTEGER(VECTOR_ELT(result, 3))[i] = (int) file_stat.m_time;
     zip_get_permissions(&file_stat, &mode);
     INTEGER(VECTOR_ELT(result, 4))[i] = (int) mode;
-    if(cextra) {
-      INTEGER(VECTOR_ELT(result, 5))[i] = (int) file_stat.m_crc32;
-      REAL(VECTOR_ELT(result, 6))[i] = (double) file_stat.m_local_header_ofs;
-    }
+    INTEGER(VECTOR_ELT(result, 5))[i] = (int) file_stat.m_crc32;
+    REAL(VECTOR_ELT(result, 6))[i] = (double) file_stat.m_local_header_ofs;
   }
 
   fclose(fh);

--- a/tests/testthat/test-zip-list.R
+++ b/tests/testthat/test-zip-list.R
@@ -4,7 +4,7 @@ test_that("can list a zip file", {
   dir.create(tmp <- tempfile())
   cat("first file", file = file.path(tmp, "file1"))
   cat("second file", file = file.path(tmp, "file2"))
-  
+
   zipfile <- tempfile(fileext = ".zip")
 
   expect_silent(
@@ -15,7 +15,7 @@ test_that("can list a zip file", {
   )
 
   expect_true(file.exists(zipfile))
-  
+
   list <- zip_list(zipfile)
   expect_equal(
     basename(list$filename),
@@ -27,4 +27,10 @@ test_that("can list a zip file", {
     c("filename", "compressed_size", "uncompressed_size", "timestamp",
       "permissions")
   )
+
+  list2 <- zip_list(zipfile, extra = TRUE)
+  expect_equal(list2[colnames(list)], list)
+  expect_equal(colnames(list2), c(colnames(list), "crc32", "offset"))
+  expect_equal(list2$offset[1], 0)
+  expect_equal(list2$crc32[1], as.hexmode(0))
 })

--- a/tests/testthat/test-zip-list.R
+++ b/tests/testthat/test-zip-list.R
@@ -25,12 +25,8 @@ test_that("can list a zip file", {
   expect_equal(
     colnames(list),
     c("filename", "compressed_size", "uncompressed_size", "timestamp",
-      "permissions")
+      "permissions", "crc32", "offset")
   )
-
-  list2 <- zip_list(zipfile, extra = TRUE)
-  expect_equal(list2[colnames(list)], list)
-  expect_equal(colnames(list2), c(colnames(list), "crc32", "offset"))
-  expect_equal(list2$offset[1], 0)
-  expect_equal(list2$crc32[1], as.hexmode(0))
+  expect_equal(list$offset[1], 0)
+  expect_equal(list$crc32[1], as.hexmode(0))
 })

--- a/tests/testthat/test-zip-list.R
+++ b/tests/testthat/test-zip-list.R
@@ -27,6 +27,6 @@ test_that("can list a zip file", {
     c("filename", "compressed_size", "uncompressed_size", "timestamp",
       "permissions", "crc32", "offset")
   )
-  expect_equal(list$offset[1], 0)
-  expect_equal(list$crc32[1], as.hexmode(0))
+  expect_true(is.numeric(list$offset))
+  expect_true(inherits(list$crc32, 'hexmode'))
 })


### PR DESCRIPTION
Dear @gaborcsardi,

I wonder if you would consider a small pull request that optionally returns extra information about the zip file, specifically the crc32 and file offset for each zip entry. I have a project where I need this information in order to rapidly access entries inside very big zip files. Since I have made this information optional at the C level, I think it is harmless and could be useful for other people.

For the test file, we see:
```
> zip_list(zipfile)
                filename compressed_size uncompressed_size
1      file44da61c6bfac/               0                 0
2 file44da61c6bfac/file1              15                10
3 file44da61c6bfac/file2              16                11
            timestamp permissions
1 2021-03-13 20:40:38         755
2 2021-03-13 20:40:38         644
3 2021-03-13 20:40:38         644
> zip_list(zipfile, extra = T)
                filename compressed_size uncompressed_size
1      file44da61c6bfac/               0                 0
2 file44da61c6bfac/file1              15                10
3 file44da61c6bfac/file2              16                11
            timestamp permissions    crc32 offset
1 2021-03-13 20:40:38         755 00000000      0
2 2021-03-13 20:40:38         644 00effe3a     47
3 2021-03-13 20:40:38         644 735af9a0    130
```

Do you think you can consider a PR?

With many thanks, Greg