### PR TITLE
Suggest use of fs and tibble classes in `zip_list()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,8 +17,10 @@ Roxygen: list(
 Config/testthat/edition: 3
 Suggests:
     covr,
+    fs,
     processx,
     R6,
     testthat,
+    tibble,
     withr
 Encoding: UTF-8

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,3 +131,39 @@ need_packages <- function(pkgs, what = "this function") {
     }
   }
 }
+
+as_tibble <- function(x) {
+  if (getOption("zip.use_tibble", TRUE) && is_installed("tibble")) {
+    tibble::as_tibble(x)
+  } else {
+    x
+  }
+}
+
+as_fs_path <- function(x) {
+  if (getOption("zip.use_fs", TRUE) && is_installed("tibble")) {
+    fs::as_fs_path(x)
+  } else {
+    x
+  }
+}
+
+as_fs_perms <- function(x) {
+  if (getOption("zip.use_fs", TRUE) && is_installed("tibble")) {
+    fs::as_fs_perms(x)
+  } else {
+    x
+  }
+}
+
+as_fs_bytes <- function(x) {
+  if (getOption("zip.use_fs", TRUE) && is_installed("tibble")) {
+    fs::as_fs_bytes(x)
+  } else {
+    x
+  }
+}
+
+is_installed <- function(pkg) {
+  isTRUE(requireNamespace(pkg, quietly = TRUE))
+}

--- a/R/zip.R
+++ b/R/zip.R
@@ -210,16 +210,16 @@ zip_list <- function(zipfile) {
   res <- .Call(c_R_zip_list, zipfile)
   df <- data.frame(
     stringsAsFactors = FALSE,
-    filename = res[[1]],
-    compressed_size = res[[2]],
-    uncompressed_size = res[[3]],
+    filename = as_fs_path(res[[1]]),
+    compressed_size = as_fs_bytes(res[[2]]),
+    uncompressed_size = as_fs_bytes(res[[3]]),
     timestamp = as.POSIXct(res[[4]], tz = "UTC", origin = "1970-01-01")
   )
   Encoding(df$filename) <- "UTF-8"
-  df$permissions <- as.octmode(res[[5]])
+  df$permissions <- as_fs_perms(as.octmode(res[[5]]))
   df$crc32 <- as.hexmode(res[[6]])
   df$offset <- res[[7]]
-  df
+  as_tibble(df)
 }
 
 #' Uncompress 'zip' Archives


### PR DESCRIPTION
This would create new options for how the data frame and columns returned by `zip_list()` appear. 

1. The [tidyverse/tibble](https://github.com/tidyverse/tibble) and [r-lib/fs](https://github.com/r-lib/fs/) packages are suggested.
2. `as_tibble()` is used _if_ the tibble package is installed.
3. The bytes, permissions, and file path columns use similar classes to `fs::file_info()` _if_ fs is installed.