### PR TITLE
Fix segfault

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # zip (development version)
 
+* Fix segmentation fault when zip file can't be created (#91, @zeehio)
+
 # zip 2.2.2
 
 * No user visible changes.

--- a/src/zip.c
+++ b/src/zip.c
@@ -285,7 +285,10 @@ int zip_zip(const char *czipfile, int num_files, const char **ckeys,
   if (cappend) {
     zfh = zip_open_utf8(czipfile, ZIP__APPEND, &filenameu16,
                         &filenameu16_len);
-    if (zfh == NULL) ZIP_ERROR(R_ZIP_EOPENAPPEND, czipfile);
+    if (zfh == NULL) {
+      if (filenameu16) free(filenameu16);
+      ZIP_ERROR(R_ZIP_EOPENAPPEND, czipfile);
+    }
     if (!mz_zip_reader_init_cfile(&zip_archive, zfh, 0, 0) ||
 	      !mz_zip_writer_init_from_reader(&zip_archive, NULL)) {
           if (filenameu16) free(filenameu16);
@@ -295,7 +298,10 @@ int zip_zip(const char *czipfile, int num_files, const char **ckeys,
   } else {
     zfh = zip_open_utf8(czipfile, ZIP__WRITE, &filenameu16,
                         &filenameu16_len);
-    if (zfh == NULL) ZIP_ERROR(R_ZIP_EOPENWRITE, czipfile);
+    if (zfh == NULL) {
+      if (filenameu16) free(filenameu16);
+      ZIP_ERROR(R_ZIP_EOPENWRITE, czipfile);
+    }
     if (!mz_zip_writer_init_cfile(&zip_archive, zfh, 0)) {
       if (filenameu16) free(filenameu16);
       fclose(zfh);

--- a/src/zip.c
+++ b/src/zip.c
@@ -295,6 +295,7 @@ int zip_zip(const char *czipfile, int num_files, const char **ckeys,
   } else {
     zfh = zip_open_utf8(czipfile, ZIP__WRITE, &filenameu16,
                         &filenameu16_len);
+    if (zfh == NULL) ZIP_ERROR(R_ZIP_EOPENWRITE, czipfile);
     if (!mz_zip_writer_init_cfile(&zip_archive, zfh, 0)) {
       if (filenameu16) free(filenameu16);
       fclose(zfh);


### PR DESCRIPTION
When `zip_open_utf8()` fails, NULL is returned.
    
That NULL is passed down and eventually ends up in `ftello64(NULL)` causing a NULL pointer dereference, aborting R.

With this check, we show an error instead