### PR TITLE
Fix zipfile delayed evaluation bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # zip (development version)
 
 * Fix segmentation fault when zip file can't be created (#91, @zeehio)
+* Fix delayed evaluation error on zipfile when `zip::zip()`
+  is used (#92, @zeehio)
 
 # zip 2.2.2
 

--- a/R/zip.R
+++ b/R/zip.R
@@ -176,6 +176,7 @@ zipr_append <- function(zipfile, files, recurse = TRUE,
 
 zip_internal <- function(zipfile, files, recurse, compression_level,
                          append, root, keep_path, include_directories) {
+  zipfile <- force(zipfile)
   oldwd <- setwd(root)
   on.exit(setwd(oldwd), add = TRUE)
 


### PR DESCRIPTION
This one is beautiful
    
Create a zip file under outdir/test.zip with "a.txt", when "a.txt" is found on a different folder:

```bash
mkdir "outdir"
mkdir "where-a.txt-is-saved"
touch "where-a.txt-is-saved/a.txt"
```

If we do it like:

```r
zip::zip(
  zipfile = file.path(normalizePath("outdir", mustWork=TRUE), "test.zip"),
  files = c("a.txt"),
  root = "where-a.txt-is-saved"
)
```
    
`normalizePath()` will fail because it will be evaluated when it is first used, and this is in `zip:::zip_internal()` after we have changed the working directory to `root`.
    
Here we force the evaluation of `zipfile` before changing the directory.

I love this delayed evaluation things :smiley: 
